### PR TITLE
Don't create a context window with width <= 0.

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -151,10 +151,15 @@ end
 function M.open()
   if winid == nil or not api.nvim_win_is_valid(winid) then
     local gutter_width = get_gutter_width()
+    local win_width = api.nvim_win_get_width(0) - gutter_width
+
+    if win_width <= 0 then
+      return
+    end
 
     winid = api.nvim_open_win(bufnr, false, {
       relative = 'win',
-      width = api.nvim_win_get_width(0) - gutter_width,
+      width = win_width,
       height = 1,
       row = 0,
       col = gutter_width,


### PR DESCRIPTION
Errors are possible when trying to create a context window for another window that is too small.

![Example image of the error](https://user-images.githubusercontent.com/6256228/96513364-f105a380-1259-11eb-9535-eaa0681bfc5f.png)

By the way, thanks for creating this plugin; it's very nice! :)
