### PR TITLE
Fix E11 and improve get_gutter_width() accuracy

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -65,33 +65,11 @@ local get_context = function(opts)
 end
 
 local get_gutter_width = function()
-  local width = api.nvim_win_get_width(0)
-  local number_width = math.max(
-    api.nvim_win_get_option(0, 'numberwidth'),
-    #tostring(api.nvim_call_function('line', { '$' })) + 1
-  )
-  local number = api.nvim_win_get_option(0, 'number')
-  local relative_number = api.nvim_win_get_option(0, 'relativenumber')
-  number_width = (number or relative_number) and number_width or 0
-  local fold_width = api.nvim_win_get_option(0, 'foldcolumn')
-
-  local sign_width = 0
-
-  local sign_column = api.nvim_win_get_option(0, 'signcolumn')
-
-  if sign_column == 'yes' then
-    sign_width = 2
-  elseif sign_column == 'auto' then
-    local signs = api.nvim_call_function('execute', {
-      'sign place buffer=' .. api.nvim_get_current_buf(),
-    })
-    local signs = vim.split(signs, '\n', true)
-    sign_width = #signs > 2 and 2 or 0
-  else
-    sign_width = 0
-  end
-
-  return number_width + fold_width + sign_width
+  local old_col = api.nvim_call_function('col', { '.' })
+  api.nvim_call_function('cursor', { 0, 1 })
+  local gutter_width = api.nvim_call_function('wincol', {}) - 1
+  api.nvim_call_function('cursor', { 0, old_col })
+  return gutter_width
 end
 
 local nvim_augroup = function(group_name, definitions)
@@ -157,10 +135,6 @@ function M.open()
   if winid == nil or not api.nvim_win_is_valid(winid) then
     local gutter_width = get_gutter_width()
     local win_width = api.nvim_win_get_width(0) - gutter_width
-
-    if win_width <= 0 then
-      return
-    end
 
     winid = api.nvim_open_win(bufnr, false, {
       relative = 'win',

--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -143,6 +143,11 @@ end
 
 function M.close()
   if winid ~= nil and api.nvim_win_is_valid(winid) then
+    -- Can't close other windows when the command-line window is open
+    if api.nvim_call_function('getcmdwintype', {}) ~= '' then
+      return
+    end
+
     api.nvim_win_close(winid, true)
   end
   winid = nil


### PR DESCRIPTION
Hi again! I thought I'd try and fix 2 other issues that I've seen:

- This PR fixes E11 errors when opening the command-line window while the context window is open (see https://github.com/neovim/neovim/pull/10738):
![E11 error image](https://user-images.githubusercontent.com/6256228/96612033-362ae380-12f5-11eb-94d7-6b33a6386922.png)

- This PR also improves the accuracy of `get_gutter_width()` by using Vim's `wincol()` function:
![image](https://user-images.githubusercontent.com/6256228/96614305-e39ef680-12f7-11eb-9b24-f04abb459230.png)
This improvement also seems to eliminate the need for my previous PR #2 for small windows.

Cheers!