### PR TITLE
More improvements.

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -221,6 +221,7 @@ function M.enable()
     {'CursorMoved', '*',               'silent lua require("treesitter-context").update_context()'},
     {'WinEnter',    '*',               'silent lua require("treesitter-context").update_context()'},
     {'WinLeave',    '*',               'silent lua require("treesitter-context").close()'},
+    {'VimResized',  '*',               'silent lua require("treesitter-context").open()'},
     {'User',        'SessionSavePre',  'silent lua require("treesitter-context").close()'},
     {'User',        'SessionSavePost', 'silent lua require("treesitter-context").open()'},
   })

--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -216,7 +216,7 @@ function M.enable()
     {'Scroll',      '*',               'silent lua require("treesitter-context").update_context()'},
     {'CursorMoved', '*',               'silent lua require("treesitter-context").update_context()'},
     {'WinEnter',    '*',               'silent lua require("treesitter-context").update_context()'},
-    {'WinLeave',    '*',               'silent lua require("treesitter-context").update_context()'},
+    {'WinLeave',    '*',               'silent lua require("treesitter-context").close()'},
     {'User',        'SessionSavePre',  'silent lua require("treesitter-context").close()'},
     {'User',        'SessionSavePost', 'silent lua require("treesitter-context").open()'},
   })

--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -141,6 +141,10 @@ function M.close()
 end
 
 function M.open()
+  if current_node == nil then
+    return
+  end
+
   local saved_bufnr = api.nvim_get_current_buf()
   local start_row = current_node:start()
   local end_row   = current_node:end_()

--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -54,7 +54,7 @@ local nvim_augroup = function(group_name, definitions)
   api.nvim_command('autocmd!')
   for _, def in ipairs(definitions) do
     local command = table.concat({'autocmd', unpack(def)}, ' ')
-    if api.nvim_call_function('exists', {'#' .. def[1]}) ~= 0 then
+    if api.nvim_call_function('exists', {'##' .. def[1]}) ~= 0 then
       api.nvim_command(command)
     end
   end


### PR DESCRIPTION
Hi again!

I've made some more small changes; details are in the commit messages.

The `WinLeave` split bug is a bit strange, though:
![split bug](https://user-images.githubusercontent.com/6256228/96775095-ee808680-13de-11eb-917e-3c953f15ece6.png)

Might possibly be caused by an issue with `nvim_win_set_config()`?
WinEnter is triggered before the file is loaded, but after the window is split when splitting windows, which maybe causes that issue _somehow_, but the same thing does not happen if `nvim_win_open()` is used instead... 