### PR TITLE
Revert "Improve get_gutter_width() accuracy using wincol()"

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -42,11 +42,33 @@ local transform_line = function(line)
 end
 
 local get_gutter_width = function()
-  local old_col = api.nvim_call_function('col', { '.' })
-  api.nvim_call_function('cursor', { 0, 1 })
-  local gutter_width = api.nvim_call_function('wincol', {}) - 1
-  api.nvim_call_function('cursor', { 0, old_col })
-  return gutter_width
+  local width = api.nvim_win_get_width(0)
+  local number_width = math.max(
+    api.nvim_win_get_option(0, 'numberwidth'),
+    #tostring(api.nvim_call_function('line', { '$' })) + 1
+  )
+  local number = api.nvim_win_get_option(0, 'number')
+  local relative_number = api.nvim_win_get_option(0, 'relativenumber')
+  number_width = (number or relative_number) and number_width or 0
+  local fold_width = api.nvim_win_get_option(0, 'foldcolumn')
+
+  local sign_width = 0
+
+  local sign_column = api.nvim_win_get_option(0, 'signcolumn')
+
+  if sign_column == 'yes' then
+    sign_width = 2
+  elseif sign_column == 'auto' then
+    local signs = api.nvim_call_function('execute', {
+      'sign place buffer=' .. api.nvim_get_current_buf(),
+    })
+    local signs = vim.split(signs, '\n', true)
+    sign_width = #signs > 2 and 2 or 0
+  else
+    sign_width = 0
+  end
+
+  return number_width + fold_width + sign_width
 end
 
 local nvim_augroup = function(group_name, definitions)
@@ -151,6 +173,10 @@ function M.open()
 
   local gutter_width = get_gutter_width()
   local win_width = api.nvim_win_get_width(0) - gutter_width
+
+  if win_width <= 0 then
+    return
+  end
 
   if winid == nil or not api.nvim_win_is_valid(winid) then
     winid = api.nvim_open_win(bufnr, false, {


### PR DESCRIPTION
This reverts commit e599c7e2515f3b6be7f3b16eb5e934f1905b5c09.

@seandewar I need to revert this commit due to the bug shown below. Modifying the cursor position mid-function clears the [curswant](https://github.com/neovim/neovim/blob/b5cd052037c532e5416919e4077b721ce6ab3a38/src/nvim/buffer_defs.h#L1140) property. If you have a different proposition to measure the gutter width let me know. Also I'm not sure which issue it solved but if you encounter it please open it so it's documented :)

![demo](https://user-images.githubusercontent.com/1423607/96956985-793cb080-14c7-11eb-83e9-cf04531fb64d.gif)
