### PR TITLE
Use nvim-treesitter locals queries

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -36,7 +36,11 @@ end
 local get_lines_for_node = function(node)
   local start_row = node:start()
   local end_row   = node:end_()
-  return api.nvim_buf_get_lines(0, start_row, end_row + 1, false)
+  return api.nvim_buf_get_lines(0, start_row, end_row + 1, false)[1]
+end
+
+local function get_lines_for_multiple_nodes(nodes)
+  return vim.tbl_map(get_lines_for_node, nodes)
 end
 
 local get_gutter_width = function()
@@ -95,12 +99,6 @@ function M.get_context(opts)
   return matches
 end
 
-function tbl_reverse(tbl)
-  for i=1, math.floor(#tbl / 2) do
-    tbl[i], tbl[#tbl - i + 1] = tbl[#tbl - i + 1], tbl[i]
-  end
-end
-
 function M.get_parent_matches()
   local contains = vim.tbl_contains
 
@@ -119,8 +117,6 @@ function M.get_parent_matches()
       break
     end
   end
-
-  tbl_reverse(parent_matches)
 
   return parent_matches
 end
@@ -207,7 +203,7 @@ function M.open()
   local gutter_width = get_gutter_width()
   local win_width = api.nvim_win_get_width(0) - gutter_width
 
-  local lines = get_text_for_multiple_nodes(current_node)
+  local lines = get_lines_for_multiple_nodes(current_node)
   if #lines <= 0 then
     return
   end

--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -83,10 +83,10 @@ local nvim_augroup = function(group_name, definitions)
   api.nvim_command('augroup END')
 end
 
-local line_changed
+local cursor_moved_vertical
 do
   local line
-  line_changed = function()
+  cursor_moved_vertical = function()
     local newline =  vim.api.nvim_win_get_cursor(0)[1]
     if newline ~= line then
       line = newline
@@ -194,10 +194,14 @@ function M.get_parent_matches()
   return parent_matches
 end
 
+local counter = 1
 function M.update_context()
-  if not line_changed() then
+  if not cursor_moved_vertical() then
     return
   end
+
+  print('updating context', counter)
+  counter = counter + 1
 
   if api.nvim_get_option('buftype') ~= '' or
       vim.fn.getwinvar(0, '&previewwindow') ~= 0 then

--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -147,6 +147,12 @@ end
 
 local M = {}
 
+function M.do_au_cursor_moved_vertical()
+  if cursor_moved_vertical() then
+    vim.cmd [[doautocmd User CursorMovedVertical]]
+  end
+end
+
 function M.get_context(opts)
   if not parsers.has_parser() then return nil end
   local options = opts or {}
@@ -195,10 +201,6 @@ function M.get_parent_matches()
 end
 
 function M.update_context()
-  if not cursor_moved_vertical() then
-    return
-  end
-
   if api.nvim_get_option('buftype') ~= '' or
       vim.fn.getwinvar(0, '&previewwindow') ~= 0 then
     M.close()
@@ -365,7 +367,9 @@ end
 function M.enable()
   nvim_augroup('treesitter_context', {
     {'WinScrolled', '*',               'silent lua require("treesitter-context").throttled_update_context()'},
-    {'CursorMoved', '*',               'silent lua require("treesitter-context").throttled_update_context()'},
+    {'User',        'CursorMovedVertical', 'silent lua require("treesitter-context").throttled_update_context()'},
+    {'CursorMoved', '*',               'silent lua require("treesitter-context").do_au_cursor_moved_vertical()'},
+    {'User', 'CursorMovedVertical',    'silent lua require("treesitter-context").throttled_update_context()'},
     {'BufEnter',    '*',               'silent lua require("treesitter-context").throttled_update_context()'},
     {'WinEnter',    '*',               'silent lua require("treesitter-context").throttled_update_context()'},
     {'WinLeave',    '*',               'silent lua require("treesitter-context").close()'},
@@ -389,6 +393,5 @@ M.enable()
 
 api.nvim_command('command! TSContextEnable  lua require("treesitter-context").enable()')
 api.nvim_command('command! TSContextDisable lua require("treesitter-context").disable()')
-
 
 return M

--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -369,7 +369,6 @@ function M.enable()
     {'WinScrolled', '*',               'silent lua require("treesitter-context").throttled_update_context()'},
     {'User',        'CursorMovedVertical', 'silent lua require("treesitter-context").throttled_update_context()'},
     {'CursorMoved', '*',               'silent lua require("treesitter-context").do_au_cursor_moved_vertical()'},
-    {'User', 'CursorMovedVertical',    'silent lua require("treesitter-context").throttled_update_context()'},
     {'BufEnter',    '*',               'silent lua require("treesitter-context").throttled_update_context()'},
     {'WinEnter',    '*',               'silent lua require("treesitter-context").throttled_update_context()'},
     {'WinLeave',    '*',               'silent lua require("treesitter-context").close()'},

--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -194,14 +194,10 @@ function M.get_parent_matches()
   return parent_matches
 end
 
-local counter = 1
 function M.update_context()
   if not cursor_moved_vertical() then
     return
   end
-
-  print('updating context', counter)
-  counter = counter + 1
 
   if api.nvim_get_option('buftype') ~= '' or
       vim.fn.getwinvar(0, '&previewwindow') ~= 0 then


### PR DESCRIPTION
From [issue](https://github.com/romgrk/nvim-treesitter-context/issues/25). This pr allows `nvim-treesitter-context` to use the locals queries provided by `nvim-treesitter`. It also allows for multi line context. I can't get the highlighting to extract the colors from the saved buffer so for now i just call `ts_highlight.attach(bufnr, ft)`which has worse syntax highlighting. Any ideas about how to implement proper syntax highlighting other than calling `ts_highlight.attach`?