### PR TITLE
Close context window on QuitPre

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -371,6 +371,7 @@ function M.enable()
     {'BufEnter',    '*',               'silent lua require("treesitter-context").update_context()'},
     {'WinEnter',    '*',               'silent lua require("treesitter-context").update_context()'},
     {'WinLeave',    '*',               'silent lua require("treesitter-context").close()'},
+    {'QuitPre',     '*',               'silent lua require("treesitter-context").close()'},
     {'VimResized',  '*',               'silent lua require("treesitter-context").open()'},
     {'User',        'SessionSavePre',  'silent lua require("treesitter-context").close()'},
     {'User',        'SessionSavePost', 'silent lua require("treesitter-context").open()'},


### PR DESCRIPTION
I usually work with multiple windows and multiple tabs, and I discovered that if you have a window with a context window open as the last window in a tab, and you try to close with `:q`, you get an `E5601`:

![2021-03-11_09-11](https://user-images.githubusercontent.com/200111/110756080-05b6f800-824a-11eb-9ddd-b862fe08894d.png)

I added a close autocmd on `QuitPre` which prevents the error.