### PR TITLE
Fix problem with doautocmd and modeline

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -206,7 +206,7 @@ local M = {}
 function M.do_au_cursor_moved_vertical()
   if cursor_moved_vertical() then
     log_message({'cursor_moved_vertical'})
-    vim.cmd [[doautocmd User CursorMovedVertical]]
+    vim.cmd [[doautocmd <nomodeline> User CursorMovedVertical]]
   end
 end
 


### PR DESCRIPTION
This fixes an issue i had trying to use nvim-treesitter-context while editing files with foldmarkers and a modeline. Everytime i moved my cursor all my folds were getting closed. I found out that `doautocmd` reloads the `modeline` which caused `foldlevel=0` from my modeline to be run again. Fortunately this can be suppressed using the `<nomodeline>` flag. I replaced every `doautocmd` call with `doautocmd <nomodeline>`.

## Example
Use the following file and command to reproduce: `nvim --clean -u test.vim test.vim`
```vim
" Test {{{
set modeline
au User Test echom 'test'
" }}}

" vim: foldmethod=marker foldenable foldlevel=0
```
![102778352-b7086900-4392-11eb-948e-f316b483b50d](https://user-images.githubusercontent.com/9465658/111885411-e8132c80-89c7-11eb-8d5e-b41d0254eb1f.gif)
