### PR TITLE
Fix the barbar focus issue introduced in #54

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -193,6 +193,7 @@ local function display_window(width, height, row, col)
       col = col,
       focusable = false,
       style = 'minimal',
+      noautocmd = true,
     })
     api.nvim_win_set_var(winid, 'treesitter_context', true)
   else


### PR DESCRIPTION
As mentioned in the referenced PR, the issue was that showing the context window was interfering with barbar displaying the current buffer as active. Previously, ts-context was calling `show()` (and thus `nvim_open_win`) from inside an autocmd handler (frequently `WinScrolled`). Because those autocmds were not declared as `++nested`, it prevented the `nvim_open_win` call from triggering any autocmds. With the introduction of throttling, the `show()` function is now getting called from inside a `defer_fn`, outside of any autocmd context. The fix is pretty simple and restores the previous behavior.