### PR TITLE
Fix width must be a positive Integer err msg when context is disabled

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -287,6 +287,10 @@ function M.get_parent_matches(type_patterns)
 end
 
 function M.update_context()
+  if not enabled then
+    return
+  end
+
   if api.nvim_get_option('buftype') ~= '' or
       vim.fn.getwinvar(0, '&previewwindow') ~= 0 then
     M.close()


### PR DESCRIPTION
Hi,

First of all: Thanks for this great plugin.

Second: I got the following error message (sometimes), when the context is enabled, I opened the quickfix window and closed the quickfix window:
```text
Error detected while processing WinEnter Autocommands for "*":
E5108: Error executing lua ...ddons/nvim-treesitter-context/lua/treesitter-context.lua:182: 'width' key must be a positive Integer
```

The problem is fixed (for me) when applying the patch below. I also think, that in general it is a good idea to only update the context, when the window is enabled.