### PR TITLE
Ensure treesitter-context buffer exists

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -61,7 +61,7 @@ local INDENT_PATTERN = '^%s+'
 local didSetup = false
 local enabled = nil
 local winid = nil
-local bufnr = api.nvim_create_buf(false, true)
+local _bufnr = nil -- Don't access directly, use get_buf()
 local ns = api.nvim_create_namespace('nvim-treesitter-context')
 local context_nodes = {}
 local context_types = {}
@@ -217,8 +217,24 @@ do
   end
 end
 
+local function get_buf()
+  if _bufnr == nil or not api.nvim_buf_is_valid(_bufnr) then
+    _bufnr = api.nvim_create_buf(false, true)
+  end
+  return _bufnr
+end
+
+local function delete_buf()
+  if _bufnr == nil or not api.nvim_buf_is_valid(_bufnr) then
+    return
+  end
+  api.nvim_buf_delete(_bufnr, { force = true })
+  _bufnr = nil
+end
+
 local function display_window(width, height, row, col)
   if winid == nil or not api.nvim_win_is_valid(winid) then
+    local bufnr = get_buf()
     winid = api.nvim_open_win(bufnr, false, {
       relative = 'win',
       width = width,
@@ -413,6 +429,7 @@ function M.open()
     table.insert(context_indents, indents)
   end
 
+  local bufnr = get_buf()
   api.nvim_buf_set_lines(bufnr, 0, -1, false, context_text)
 
   -- api.nvim_command('echom ' .. vim.fn.json_encode({
@@ -531,8 +548,8 @@ end
 
 function M.disable()
   nvim_augroup('treesitter_context_update', {})
-
   M.close()
+  delete_buf()
   enabled = false
 end
 

--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -225,10 +225,9 @@ local function get_buf()
 end
 
 local function delete_buf()
-  if _bufnr == nil or not api.nvim_buf_is_valid(_bufnr) then
-    return
+  if _bufnr ~= nil and api.nvim_buf_is_valid(_bufnr) then
+    api.nvim_buf_delete(_bufnr, { force = true })
   end
-  api.nvim_buf_delete(_bufnr, { force = true })
   _bufnr = nil
 end
 


### PR DESCRIPTION
Improves compatibility with other plugins such as session managers that like to delete buffers. Previously, if another plugin deleted this plugin's buffer, treesitter-context would error out upon trying to show the context window. Now, the buffer is re-created if it doesn't exist. The buffer is also now deleted when `disable()` is called.

Side note:

<details>
  <summary>Click to expand</summary>

This isn't directly related, but I don't really like having so many module-level state variables. I think the code would be nicer if they were all kept inside a `state` table:

```lua
-- Current
local didSetup = false
local enabled = nil
local winid = nil
local bufnr = api.nvim_create_buf(false, true)
local _bufnr = nil -- Don't access directly, use get_buf()
local ns = api.nvim_create_namespace('nvim-treesitter-context')
local context_nodes = {}
local context_types = {}
local previous_nodes = nil

-- Proposal
local state = {
  didSetup = false,
  enabled = nil,
  winid = nil,
  bufnr = nil, -- Don't access directly, use get_buf()
  ns = api.nvim_create_namespace('nvim-treesitter-context'),
  context_nodes = {},
  context_types = {},
  previous_nodes = nil,
}
```

Then there's no worry about shadowing, which is why I originally changed `bufnr` to `_bufnr`.

</details>