### PR TITLE
(fix #80) iterate parents from top, move visible line for each match

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -296,15 +296,23 @@ function M.get_parent_matches()
   local last_row = -1
   local first_visible_line = api.nvim_call_function('line', { 'w0' })
 
+  -- save nodes in a table to iterate from top to bottom
+  local parents = {}
   while current ~= nil do
-    local position = {current:start()}
+    parents[#parents+1] = current
+    current = current:parent()
+  end
+
+  for i = #parents, 1, -1 do
+    local parent = parents[i]
+    local position = {parent:start()}
     local row = position[1]
 
-    if is_valid(current, filetype)
+    if is_valid(parent, filetype)
         and row > 0
-        and row < (first_visible_line - 1)
+        and row < (first_visible_line + #parent_matches - 1)
         and row ~= last_row then
-      table.insert(parent_matches, current)
+      table.insert(parent_matches, 1, parent)
 
       if row ~= last_row then
         lines = lines + 1
@@ -314,7 +322,6 @@ function M.get_parent_matches()
         break
       end
     end
-    current = current:parent()
   end
 
   return parent_matches


### PR DESCRIPTION
This should fix #80. It includes a bit of complexity since it iterates the parents array twice, but it was only way I could find to do so.

It iterates the parent nodes from the top, and for each node that should be added to the context, we increment the visible line by 1, so the children nodes can be added if they end up above that new line.

EDIT: adding gifs as examples

- Without fix
  ![context-without-fix](https://user-images.githubusercontent.com/24478021/143627314-0a2ae11f-5d3f-4920-8f32-23e6823e382b.gif)

- With fix
  ![context-with-fix](https://user-images.githubusercontent.com/24478021/143627286-f07f13db-4cdd-424b-888e-40e4637da812.gif)