### PR TITLE
Use getwininfo() instead of FFI to get gutter width in Nvim 0.6

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -15,8 +15,13 @@ local defaultConfig = {
 
 local config = {}
 
-local ffi = require("ffi")
-ffi.cdef'int curwin_col_off(void);'
+local has_textoff = vim.fn.has('nvim-0.6')
+
+local ffi = nil
+if not has_textoff then
+  ffi = require("ffi")
+  ffi.cdef'int curwin_col_off(void);'
+end
 
 -- Constants
 
@@ -189,7 +194,11 @@ local get_indents = function(lines)
 end
 
 local get_gutter_width = function()
-  return ffi.C.curwin_col_off();
+  if not has_textoff then
+    return ffi.C.curwin_col_off();
+  else
+    return vim.fn.getwininfo(vim.api.nvim_get_current_win())[1].textoff
+  end
 end
 
 local nvim_augroup = function(group_name, definitions)


### PR DESCRIPTION
It is no longer necessary to rely on an Nvim internal C function.