### PR TITLE
Enable full lua patterns as node types on user demand

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ require'treesitter-context'.setup{
         --       'impl_item',
         --   },
     },
+    exact_patterns = {
+        -- Example for a specific filetype with Lua patterns
+        -- Treat patterns.rust as a Lua pattern (i.e "^impl_item$" will
+        -- exactly match "impl_item" only)
+        -- rust = true, 
+    }
 }
 ```
 

--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -53,6 +53,7 @@ local DEFAULT_TYPE_PATTERNS = {
     'architecture_body',
     'entity_declaration',
   },
+  exact_patterns = {},
 }
 local INDENT_PATTERN = '^%s+'
 
@@ -560,9 +561,14 @@ function M.setup(options)
   config = vim.tbl_deep_extend("force", {}, defaultConfig, userOptions)
   config.patterns =
     vim.tbl_deep_extend("force", {}, DEFAULT_TYPE_PATTERNS, userOptions.patterns or {})
+  config.exact_patterns =
+    vim.tbl_deep_extend("force", {}, userOptions.exact_patterns or {})
 
   for filetype, patterns in pairs(config.patterns) do
-    config.patterns[filetype] = vim.tbl_map(word_pattern, patterns)
+    -- Map with word_pattern only if users don't need exact pattern matching
+    if not config.exact_patterns[filetype] then
+        config.patterns[filetype] = vim.tbl_map(word_pattern, patterns)
+    end
   end
 
   if config.enable then


### PR DESCRIPTION
I was trying to make this neat piece of software work with my own TreeSitter grammar when I discovered
that matched node types are mapped with `word_pattern` function. In my grammar, I have `dict` and `dict_body` nodes and
I would like to match only `dict`.

So, I added a user setting to turn off that mapping, and use bare Lua patterns instead. Now I can live with `^dict$`.