### PR TITLE
Omit PHP attributes from class/method context.

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -32,6 +32,17 @@ local last_types = {
   },
 }
 
+-- Tells us which leading child node type to skip when highlighting a
+-- multi-line node.
+local skip_leading_types = {
+  [word_pattern('class')] = {
+    php = 'attribute_list',
+  },
+  [word_pattern('method')] = {
+    php = 'attribute_list',
+  },
+}
+
 -- There are language-specific
 local DEFAULT_TYPE_PATTERNS = {
   -- These catch most generic groups, eg "function_declaration" or "function_block"
@@ -123,6 +134,20 @@ local function find_node(node, type)
 end
 
 local get_text_for_node = function(node)
+  local type = get_type_pattern(node, config.patterns.default) or node:type()
+  local filetype = api.nvim_buf_get_option(0, 'filetype')
+
+  local skip_leading_type = (skip_leading_types[type] or {})[filetype]
+  if skip_leading_type then
+    local children = ts_utils.get_named_children(node)
+    for _, child in ipairs(children) do
+      if child:type() ~= skip_leading_type then
+        node = child
+        break
+      end
+    end
+  end
+
   local start_row, start_col = node:start()
   local end_row, end_col     = node:end_()
 
@@ -133,8 +158,6 @@ local get_text_for_node = function(node)
   end
   start_col = 0
 
-  local type = get_type_pattern(node, config.patterns.default) or node:type()
-  local filetype = api.nvim_buf_get_option(0, 'filetype')
   local last_type = (last_types[type] or {})[filetype]
   local last_position = nil
 


### PR DESCRIPTION
Bug: The context line shows PHP 8 class or method attributes instead of the class/method definition. This PR is an attempt to fix that.

Before:
<img width="809" alt="0before" src="https://user-images.githubusercontent.com/508999/146551644-3d9eb5da-9ccf-49f9-b14a-d18d3dda9eaf.png">

With this PR:
<img width="809" alt="1after" src="https://user-images.githubusercontent.com/508999/146551659-182431f0-f76b-48a2-9bb9-79e5fc8fb7ed.png">

:TSPlayground
<img width="1510" alt="3tsplayground" src="https://user-images.githubusercontent.com/508999/146551661-aeaa1440-6cc1-488c-8760-e29dfefa9054.png">

Test code:
```php
<?php

use Attribute;

#[Attribute(Attribute::TARGET_CLASS)]
class ClassAttr { }

#[Attribute(Attribute::TARGET_METHOD)]
class MethodAttr { }

/**
 * hello
 */
#[ClassAttr]
class Inventory
{
	/**
	 * @throws \Exception
	 */
	#[MethodAttr]
	public static function testasdf(array $args): void
	{
		// asdf
	}
}
```