### PR TITLE
show function arguments for python and rust

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -32,6 +32,8 @@ local last_types = {
     c = 'function_declarator',
     cpp = 'function_declarator',
     lua = 'parameters',
+    python = 'parameters',
+    rust = 'parameters',
     javascript = 'formal_parameters',
     typescript = 'formal_parameters',
   },


### PR DESCRIPTION
Thank you for this awesome plugin! Especially since I discovered that I can easily extend the treesitter patterns to be added to the context :) 

This adds config to show function arguments for python and rust. 