### PR TITLE
show parent items when they are on the screen but behind the context

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -344,7 +344,6 @@ function M.get_parent_matches()
   local filetype = api.nvim_buf_get_option(0, 'filetype')
   local lines = 0
   local last_row = -1
-  local first_visible_line = api.nvim_call_function('line', { 'w0' })
 
   while current ~= nil do
     local position = {current:start()}
@@ -352,9 +351,8 @@ function M.get_parent_matches()
 
     if is_valid(current, filetype)
         and row > 0
-        and row < (first_visible_line - 1)
         and row ~= last_row then
-      table.insert(parent_matches, current)
+      table.insert(parent_matches, {current, row})
 
       if row ~= last_row then
         lines = lines + 1
@@ -367,7 +365,17 @@ function M.get_parent_matches()
     current = current:parent()
   end
 
-  return parent_matches
+  local first_visible_line = api.nvim_call_function('line', { 'w0' }) + lines
+
+  local result = {}
+  for _, pm in ipairs(parent_matches) do
+	  local node, row = unpack(pm)
+	  if row < (first_visible_line - 1) then
+		  table.insert(result, node)
+      end
+  end
+
+  return result
 end
 
 function M.update_context()


### PR DESCRIPTION
Last time I did you is quite some time ago, so I'm not 100% certain if this is the best approach.

With this change context items that were previously hidden behind the context overlay will be added to the context. 