### PR TITLE
rust: include return-type in function context

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -33,7 +33,7 @@ local last_types = {
     cpp = 'function_declarator',
     lua = 'parameters',
     python = 'parameters',
-    rust = 'parameters',
+    rust = 'generic_type',
     javascript = 'formal_parameters',
     typescript = 'formal_parameters',
   },


### PR DESCRIPTION
I missed that part when doing b7d7aba81683c1cd76141e090ff335bb55332cba 