### PR TITLE
Fix: make `merge_lines` not leave trailing spaces

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -196,16 +196,11 @@ end
 
 -- Merge lines, removing the indentation after 1st line
 local merge_lines = function(lines)
-  local text = ''
-  for i, line in ipairs(lines) do
-    if i == 1 then
-      text = text .. line
-    else
-      text = text .. line:gsub(INDENT_PATTERN, '')
-    end
-    text = text .. ' '
+  local text = { lines[1] }
+  for i = 2, #lines do
+    text[i] = lines[i]:gsub(INDENT_PATTERN, '')
   end
-  return text
+  return table.concat(text, ' ')
 end
 
 -- Get indentation for lines except first


### PR DESCRIPTION
Additionally, don't use a string as an accumulator since Lua strings are
constant and will be copied on each concatenation. Use a table and
`table.concat` as is recommended.

closes #104