### PR TITLE
Turn off automatic folding in the context window

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -291,6 +291,7 @@ local function display_window(width, height, row, col)
     })
   end
   api.nvim_win_set_option(winid, 'winhl', 'NormalFloat:TreesitterContext')
+  api.nvim_win_set_option(winid, 'foldmethod', 'manual')
 end
 
 -- Exports


### PR DESCRIPTION
Syntax or indent folding inherited by the context display window can fold the context data.
I propose setting the foldmethod to manual by default so this doesn't happen