### PR TITLE
fix #28: cursor is hidden behind context window

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -447,11 +447,13 @@ function M.open()
   display_window(win_width, win_height, 0, gutter_width)
 
   -- Adjust &scrolloff to prevent the cursor from moving below the window
-  local so = vim.fn.getwinvar(0, '&scrolloff')
-  if win_height > so then
-      vim.fn.setwinvar(0, '&scrolloff', win_height)
-  else
-      vim.fn.setwinvar(0, '&scrolloff', -1)
+  if config.max_lines <= 0 then
+      local so = vim.fn.getwinvar(0, '&scrolloff')
+      if win_height > so then
+          vim.fn.setwinvar(0, '&scrolloff', win_height)
+      else
+          vim.fn.setwinvar(0, '&scrolloff', -1)
+      end
   end
 
   -- Set text

--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -446,6 +446,14 @@ function M.open()
 
   display_window(win_width, win_height, 0, gutter_width)
 
+  -- Adjust &scrolloff to prevent the cursor from moving below the window
+  local so = vim.fn.getwinvar(0, '&scrolloff')
+  if win_height > so then
+      vim.fn.setwinvar(0, '&scrolloff', win_height)
+  else
+      vim.fn.setwinvar(0, '&scrolloff', -1)
+  end
+
   -- Set text
 
   local context_ranges = {}


### PR DESCRIPTION
Not sure if `scrolloff` should be adjusted less often, depending on how often that function is actually called.