### PR TITLE
Call `get_node_text` from built-in `vim.treesitter`

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -159,7 +159,7 @@ local get_text_for_node = function(node)
   local start_row, start_col = node:start()
   local end_row, end_col     = node:end_()
 
-  local lines = ts_utils.get_node_text(node)
+  local lines = vim.treesitter.query.get_node_text(node)
 
   if start_col ~= 0 then
     lines[1] = api.nvim_buf_get_lines(0, start_row, start_row + 1, false)[1]


### PR DESCRIPTION
The `get_node_text` function has been merged into the built-in `vim.treesitter` module